### PR TITLE
Version 0.2.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,4 +14,4 @@ REM Run the maturin build via pip
 set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
 set TMPDIR=tmpbuild_%PY_VER%
-%PYTHON% -m pip install . -vv
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,4 +12,4 @@ popd
 
 # Run the maturin build via pip which works for direct and
 # cross-compiled builds.
-$PYTHON -m pip install . -vv
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,12 +19,12 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - make
-    - maturin 1.3.0
+    - maturin
     - cargo-bundle-licenses
   host:
     - python
     - pip
-    - maturin
+    - maturin 1.3.0
     - toml
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
 requirements:
   build:
     - python
-    - cross-python_{{ target_platform }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
@@ -27,6 +26,8 @@ requirements:
     - pip
     - maturin
     - toml
+    - wheel
+
   run:
     - python
 
@@ -45,14 +46,13 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: An extremely fast Python linter, written in Rust.
-
-  # The remaining entries in this section are optional, but recommended.
   description: |
     An extremely fast Python linter, written in Rust. Ruff can be used to
     replace Flake8 (plus a variety of plugins), isort, pydocstyle, yesqa, and
     even a subset of pyupgrade and autoflake all while executing tens or
     hundreds of times faster than any individual tool.
   dev_url: https://github.com/charliermarsh/ruff
+  doc_url: https://docs.astral.sh/ruff/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [win]
-  missing_dso_whitelist:
-    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:
@@ -27,7 +25,7 @@ requirements:
   host:
     - python
     - pip
-    - maturin 1.3.0
+    - maturin
     - toml
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - make
-    - maturin
+    - maturin 1.3.0
     - cargo-bundle-licenses
   host:
     - python
@@ -27,7 +27,6 @@ requirements:
     - maturin
     - toml
     - wheel
-
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   skip: True  # [win]
+  missing_dso_whitelist:
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:
@@ -27,7 +29,6 @@ requirements:
     - pip
     - maturin 1.3.0
     - toml
-    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - python
+    - cross-python_{{ target_platform }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
@@ -31,7 +31,10 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   commands:
+    - pip check
     - ruff --help
   imports:
     - ruff


### PR DESCRIPTION
ruff 0.2.2

**Destination channel:** defaults

### Links

- [PKG-4208](https://anaconda.atlassian.net/browse/PKG-4208)
- [Upstream repository](https://github.com/astral-sh/ruff/tree/v0.2.2)
- [Upstream changelog/diff](https://github.com/astral-sh/ruff/blob/v0.2.2/CHANGELOG.md)

### Explanation of changes:

- Add new submodule
- Linter fixes


[PKG-4208]: https://anaconda.atlassian.net/browse/PKG-4208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ