### PR TITLE
V0.3.5

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,4 +14,4 @@ REM Run the maturin build via pip
 set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
 set TMPDIR=tmpbuild_%PY_VER%
-%PYTHON% -m pip install . -vv
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,4 +12,4 @@ popd
 
 # Run the maturin build via pip which works for direct and
 # cross-compiled builds.
-$PYTHON -m pip install . -vv
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,8 @@
 # Address failing osx build which started in 0.1.14
 # https://conda-forge.org/docs/maintainer/knowledge_base.html#requiring-newer-macos-sdks
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-  - "10.12"                # [osx and x86_64]
+macos_min_version:
+  - 10.12 # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.12 # [osx and x86_64]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.12.sdk        # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - python
     - {{ compiler('rust') }}
+    - make  # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,7 @@ build:
 requirements:
   build:
     - python
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
-    - make  # [unix]
     - maturin
     - cargo-bundle-licenses
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,14 +44,13 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: An extremely fast Python linter, written in Rust.
-
-  # The remaining entries in this section are optional, but recommended.
   description: |
     An extremely fast Python linter, written in Rust. Ruff can be used to
     replace Flake8 (plus a variety of plugins), isort, pydocstyle, yesqa, and
     even a subset of pyupgrade and autoflake all while executing tens or
     hundreds of times faster than any individual tool.
   dev_url: https://github.com/charliermarsh/ruff
+  doc_url: https://docs.astral.sh/ruff
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,10 @@ build:
 requirements:
   build:
     - python
+    - {{ compiler('c') }}     # [linux]
+    - {{ compiler('cxx') }}   # [linux]
     - {{ compiler('rust') }}
-    - make  # [linux]
+    - make                    # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
-    - make
+    - make  # [unix]
     - maturin
     - cargo-bundle-licenses
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,25 +14,27 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - python
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
-    - make
     - maturin
     - cargo-bundle-licenses
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     - maturin
-    - toml
   run:
     - python
 
 test:
+  requires:
+    - pip
   commands:
     - ruff --help
+    - pip check
   imports:
     - ruff
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,14 +18,15 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
+    - make
     - maturin
     - cargo-bundle-licenses
   host:
     - python
     - pip
-    - setuptools
-    - wheel
     - maturin
+    - toml
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  missing_dso_whitelist:
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruff" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e62ed7f36b3068a30ba39193a14274cd706bc486fad521276458022f7bccb31d
+  sha256: a067daaeb1dc2baf9b82a32dae67d154d95212080c80435eb052d95da647763d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - pip
     - maturin
     - toml
-    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   build:
     - python
     - {{ compiler('rust') }}
-    - maturin
+    - maturin >=1.0,<2.0
     - cargo-bundle-licenses
   host:
     - python


### PR DESCRIPTION
ruff 0.3.5

**Destination channel:** defaults

### Links

- [PKG-4208](https://anaconda.atlassian.net/browse/PKG-4208)
- [Upstream repository](https://github.com/astral-sh/ruff/tree/v0.2.2)
- [Upstream changelog/diff](https://github.com/astral-sh/ruff/blob/v0.2.2/CHANGELOG.md)

### Explanation of changes:

- Add new submodule
- Linter fixes

[PKG-4208]: https://anaconda.atlassian.net/browse/PKG-4208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ