### PR TITLE
Rebuild with rust 1.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a067daaeb1dc2baf9b82a32dae67d154d95212080c80435eb052d95da647763d
 
 build:
-  number: 0
+  number: 1
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6208](https://anaconda.atlassian.net/browse/PKG-6208)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6208]: https://anaconda.atlassian.net/browse/PKG-6208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ