### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruff" %}
-{% set version = "0.3.5" %}
+{% set version = "0.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a067daaeb1dc2baf9b82a32dae67d154d95212080c80435eb052d95da647763d
+  sha256: 143f68fa5560ecf10fc49878b73cee3eab98b777fcf43b0e62d43d42f5ef9d8b
 
 build:
-  number: 2
+  number: 0
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]
 
@@ -26,7 +26,7 @@ requirements:
   host:
     - python
     - pip
-    - maturin
+    - maturin >=1.0,<2.0
     - toml
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruff" %}
-{% set version = "0.9.0" %}
+{% set version = "0.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 143f68fa5560ecf10fc49878b73cee3eab98b777fcf43b0e62d43d42f5ef9d8b
+  sha256: fd2b25ecaf907d6458fa842675382c8597b3c746a2dde6717fe3415425df0c17
 
 build:
   number: 0
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]
+
+  script_env:
+    - JEMALLOC_SYS_WITH_LG_PAGE=16
 
 requirements:
   build:
@@ -23,6 +26,7 @@ requirements:
     - make                    # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
+    - git                     # [unix]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a067daaeb1dc2baf9b82a32dae67d154d95212080c80435eb052d95da647763d
 
 build:
-  number: 1
+  number: 2
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]
 


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 0.9.1
https://github.com/astral-sh/ruff/tree/0.9.1