### PR TITLE
ruff 0.12.0 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,0 @@
-# Address failing osx build which started in 0.1.14
-# https://conda-forge.org/docs/maintainer/knowledge_base.html#requiring-newer-macos-sdks
-macos_min_version:
-  - 10.12 # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.12 # [osx and x86_64]
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.12.sdk        # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ build:
 requirements:
   build:
     - python
-    # The C compiler is required because of missing libgcc-ng on linux
-    - {{ compiler('c') }}     # [linux]
     - {{ compiler('rust') }}
-    - make                    # [linux]
+    # The C compiler is required because of missing libgcc-ng on linux
+    - {{ compiler('c') }}  # [linux]
+    - make  # [linux]
+    - git  # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
-    - git                     # [linux]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     # The C compiler is required because of missing libgcc-ng on linux
     - {{ compiler('c') }}  # [linux]
     - make  # [linux]
-    # - git  # [linux]
+    - git  # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - python
     - {{ compiler('rust') }}
-    # The C compiler is required because of missing libgcc-ng on linux
     - {{ compiler('c') }}  # [linux]
     - make  # [linux]
     - git  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ test:
   commands:
     - ruff --help
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   imports:
     - ruff
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,19 +14,17 @@ build:
   skip: True  # [py<37]
   script_env:
     - JEMALLOC_SYS_WITH_LG_PAGE=16
-  # ignore_run_exports:
-    # - libstdcxx-ng
 
 requirements:
   build:
     - python
+    # The C compiler is required because of missing libgcc-ng on linux
     - {{ compiler('c') }}     # [linux]
-    - {{ compiler('cxx') }}   # [linux]
     - {{ compiler('rust') }}
     - make                    # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
-    - git                     # [unix]
+    - git                     # [linux]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruff" %}
-{% set version = "0.9.1" %}
+{% set version = "0.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,15 +7,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fd2b25ecaf907d6458fa842675382c8597b3c746a2dde6717fe3415425df0c17
+  sha256: 4d047db3662418d4a848a3fdbfaf17488b34b62f527ed6f10cb8afd78135bc5c
 
 build:
   number: 0
-  missing_dso_whitelist:
-    - '$RPATH/ld64.so.1'  # [s390x]
-
+  skip: True  # [py<37]
   script_env:
     - JEMALLOC_SYS_WITH_LG_PAGE=16
+  # ignore_run_exports:
+    # - libstdcxx-ng
 
 requirements:
   build:
@@ -45,7 +45,7 @@ test:
     - ruff
 
 about:
-  home: https://github.com/charliermarsh/ruff
+  home: https://github.com/astral-sh/ruff
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -55,7 +55,7 @@ about:
     replace Flake8 (plus a variety of plugins), isort, pydocstyle, yesqa, and
     even a subset of pyupgrade and autoflake all while executing tens or
     hundreds of times faster than any individual tool.
-  dev_url: https://github.com/charliermarsh/ruff
+  dev_url: https://github.com/astral-sh/ruff
   doc_url: https://docs.astral.sh/ruff
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     # The C compiler is required because of missing libgcc-ng on linux
     - {{ compiler('c') }}  # [linux]
     - make  # [linux]
-    - git  # [linux]
+    # - git  # [linux]
     - maturin >=1.0,<2.0
     - cargo-bundle-licenses
   host:


### PR DESCRIPTION
ruff 0.12.0 

**Destination channel:** Defaults

### Links

- [PKG-8409]
- dev_url:        https://github.com/charliermarsh/ruff/tree/0.12.0
- conda_forge:    https://github.com/conda-forge/ruff-feedstock
- pypi:           https://pypi.org/project/ruff/0.12.0
- pypi inspector: https://inspector.pypi.io/project/ruff/0.12.0

### Explanation of changes:

- new version number


[PKG-8409]: https://anaconda.atlassian.net/browse/PKG-8409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ